### PR TITLE
bgpd: BGPd crashes when changing the label assignment from static to …

### DIFF
--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -1002,7 +1002,10 @@ void vpn_leak_from_vrf_withdraw_all(struct bgp *bgp_vpn, /* to */
 							   __func__);
 					bgp_aggregate_decrement(bgp_vpn, &bn->p,
 								bi, afi, safi);
-					bgp_info_delete(bn, bi);
+					if (!CHECK_FLAG(bgp_vrf->vpn_policy[afi].flags,
+							BGP_VPN_POLICY_TOVPN_LABEL_AUTO)) {
+						bgp_info_delete(bn, bi);
+					}
 					bgp_process(bgp_vpn, bn, afi, safi);
 				}
 			}

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -6392,6 +6392,11 @@ DEFPY (af_label_vpn_export,
 	/*
 	 * pre-change: un-export vpn routes (vpn->vrf routes unaffected)
 	 */
+        if (label_auto) {
+                SET_FLAG(bgp->vpn_policy[afi].flags,
+                         BGP_VPN_POLICY_TOVPN_LABEL_AUTO);
+        }
+
 	vpn_leak_prechange(BGP_VPN_POLICY_DIR_TOVPN, afi,
 			   bgp_get_default(), bgp);
 
@@ -6420,8 +6425,6 @@ DEFPY (af_label_vpn_export,
 
 	bgp->vpn_policy[afi].tovpn_label = label;
 	if (label_auto) {
-		SET_FLAG(bgp->vpn_policy[afi].flags,
-			 BGP_VPN_POLICY_TOVPN_LABEL_AUTO);
 		bgp_lp_get(LP_TYPE_VRF, &bgp->vpn_policy[afi],
 			   vpn_leak_label_callback);
 	}


### PR DESCRIPTION
…auto(2723)

When the label assignment is changed to auto, the info node pinter was being
 deleted for the prefix, which result in the crash when being accessed.

Signed-off-by: Kishore Aramalla <karamalla@vmware.com>